### PR TITLE
Remove sort to support CosmosDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/
 
 # OS X generated files and folders
 .DS_Store
+package-lock.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ version: "{build}"
 
 environment:
   NODE_VERSION: 8.9.4
-  MONGO_VERSION: 3.6.2
+  MONGO_VERSION: 3.2.9
 
 install:
   # Install Node.js

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   timezone: Europe/Berlin
 
   environment:
-    MONGO_VERSION: 3.6.2
+    MONGO_VERSION: 3.2.9
 
   services:
     - docker

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -49,8 +49,7 @@ mongo.db = async function (connectionString, options = {}) {
 
         async findFile (fileName) {
           const cursor = db.gridfs.cachedfs.bucket.find(
-            { filename: fileName },
-            { sort: { uploadedDate: -1 } }
+            { filename: fileName }
           );
 
           let file;


### PR DESCRIPTION
I had to downgrade to Mongo 3.2 as AppVeyor build does not install Mongo 3.6 correctly.

connects to #3